### PR TITLE
HACS validation update

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,4 +16,3 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: integration
-          ignore: brands


### PR DESCRIPTION
Follow-up to #2:
- Removed "ignore: brands" from HACS validation workflow